### PR TITLE
Use CARGO_PKG_VERSION when git is not installed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,30 +81,22 @@ fn generate_completions(
  @return String
 */
 fn get_version() -> String {
-    let mut version_env: String = "".to_string();
     let mut cmd = process::Command::new("git");
 
     cmd.arg("describe");
     cmd.arg("--abbrev=0");
     cmd.arg("--tags=0");
 
-    match cmd.status() {
-        Ok(status) => {
-            if status.success() {
-                if let Ok(output) = cmd.output() {
-                    return format!("{:?}", output);
-                }
-            } else {
-                println!("Error: Cannot get build version using `git` using CARGO_PKG_VERSION");
-                version_env = env!("CARGO_PKG_VERSION").to_string();
+    if let Ok(status) = cmd.status() {
+        if status.success() {
+            if let Ok(output) = cmd.output() {
+                return format!("{:?}", output);
             }
-        }
-        Err(e) => {
-            panic!("Error: Failed getting build version with git: {}", e);
         }
     }
 
-    version_env
+    println!("Error: Cannot get build version using `git` using CARGO_PKG_VERSION");
+    return env!("CARGO_PKG_VERSION").to_string();
 }
 
 /*


### PR DESCRIPTION
While creating an nixpkgs package for envio (see [NixOS/nixpkgs#288270](https://github.com/NixOS/nixpkgs/pull/288270)) I noticed that the build failed due to `get_version` in `build.rs` trying to execute `git` which does not exist in the nixpkgs build environment.

If my understanding of the implementation of `get_version` and its comment is correct it seems there is a discrepancy as the code panics instead of using _"the version from the Cargo.toml file" if it fails to use `git describe` to get the version.

The changes below retrieve the version from the `CARGO_PKG_VERSION` environment variable regardless of whether git can be executed or `git describe` fails.
