### PR TITLE
Stream output from launched command

### DIFF
--- a/src/bin/envio/commands.rs
+++ b/src/bin/envio/commands.rs
@@ -354,17 +354,15 @@ impl Command {
                         return;
                     };
 
-                let output = std::process::Command::new(&program)
+                let mut cmd = std::process::Command::new(&program)
                     .envs(profile.envs)
                     .args(args)
-                    .output()
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .spawn()
                     .expect("Failed to execute command");
-
-                if output.stderr.is_empty() {
-                    println!("{}", String::from_utf8(output.stdout).unwrap());
-                } else {
-                    println!("{}", String::from_utf8(output.stderr).unwrap());
-                }
+                let status = cmd.wait().unwrap();
+                std::process::exit(status.code().unwrap());
             }
 
             Command::Remove { profile_name, envs } => {


### PR DESCRIPTION
Envio collects the output of launched commands, if the command is short-lived that is reasonable, yet if the command takes a long time and streams messages to stdout and/or stderr seeing these messages as the command runs is very helpful.

Image a simple script that prints the current date and time every second:
```sh
#!/bin/sh

while :; do
  date
  sleep 1
done
```

When launched via `envio profile -c 'sh ./clock.sh` nothing is printed to the terminal. With the changes proposed in this PR however the date and time appears every second.

What are your thoughts on this, @humblepenguinn?
