### PR TITLE
Add support for nix flakes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,0 +1,13 @@
+name: "Build legacy Nix package on Ubuntu"
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - name: Building package
+        run: nix-build . -A defaultPackage.x86_64-linux

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709038661,
+        "narHash": "sha256-Ys611iT6pChGv954aa4f8oKoDKJG3IXjJjPhnj6uaLY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8520c158aee718c6e87b56881105fc4223c3c723",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1709058270,
+        "narHash": "sha256-Z302zyK1FWY7NtA+wmjBb8OYvOyqLBjYztSr4F/m52M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "923c6a8b5ceb45f1de10ace4e410423393ddb0b0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "master",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "nixpkgs/master";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+  utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+      naersk-lib = pkgs.callPackage naersk { };
+    in
+    rec {
+      defaultPackage = naersk-lib.buildPackage {
+        src = ./.;
+        nativeBuildInputs = with pkgs; [ pkg-config ];
+        buildInputs = with pkgs; [ libgpg-error gpgme ]
+          ++ lib.optional pkgs.hostPlatform.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
+      };
+      devShell = with pkgs; mkShell {
+        nativeBuildInputs = defaultPackage.nativeBuildInputs;
+        buildInputs = [ cargo rustc rustfmt pre-commit ] ++ defaultPackage.buildInputs;
+        RUST_SRC_PATH = rustPlatform.rustLibSrc;
+      };
+    }
+  );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
This PR adds support for nix flake allowing folks using nix to quickly and easily run `envio`, e.g. `nix run github:/envio-cli/envio -- list -vp`

The files added in this PR have been created by running `nix flake init --template templates#rust` (see [original rust template](https://github.com/nix-community/templates/tree/main/rust)) and modified in order to satisfy envio's requirements.

To test the changes prior to merging run: `nix run github:envio-cli/envio/pull/51/merge -- list -vp`