### PR TITLE
Set vim_mode if VISUAL contains n?vim?

### DIFF
--- a/src/bin/envio/commands.rs
+++ b/src/bin/envio/commands.rs
@@ -1,7 +1,6 @@
 use colored::Colorize;
 use inquire::{min_length, Confirm, MultiSelect, Password, PasswordDisplayMode, Select, Text};
 
-use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 use std::io::Read;

--- a/src/bin/envio/commands.rs
+++ b/src/bin/envio/commands.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 use inquire::{min_length, Confirm, MultiSelect, Password, PasswordDisplayMode, Select, Text};
+use regex::Regex;
 
 use std::collections::HashMap;
 use std::env;
@@ -54,9 +55,7 @@ fn get_vim_mode() -> Result<bool, String> {
         .and_then(|stem| stem.to_str())
         .ok_or("")?; // Same here
 
-    let is_vim = program_stem.contains("vim");
-
-    Ok(is_vim)
+    Ok(Regex::new(r"n?vim?").unwrap().is_match(program_stem)) // unwrap is safe here because we know that the regex will always compile
 }
 
 impl Command {

--- a/src/bin/envio/commands.rs
+++ b/src/bin/envio/commands.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 use inquire::{min_length, Confirm, MultiSelect, Password, PasswordDisplayMode, Select, Text};
 
+use regex::Regex;
 use std::collections::HashMap;
 use std::env;
 use std::io::Read;
@@ -45,11 +46,9 @@ impl Command {
      */
     pub fn run(&self) {
         let vim_mode = if let Ok(value) = env::var("VISUAL") {
-            if let Ok(boolean_value) = value.parse::<bool>() {
-                boolean_value
-            } else {
-                false
-            }
+            let path = value.split(' ').next().unwrap();
+            let program = Path::new(path).file_stem().unwrap().to_str().unwrap();
+            Regex::new(r"n?vim?").unwrap().is_match(program)
         } else {
             false
         };


### PR DESCRIPTION
@humblepenguinn could you lend your Rust expertise on this and advise on how to best code this to avoid use of `unwrap`? I'm unfamiliar with Rust best practices in this regard…

As for the PR itself I think it is reasonable to parse the value of `VISUAL` to check whether it contains something that is likely an editor from the `vi` family. The code should handle relative and absolute paths, as well as additional command options contained in `VISUAL`, e.g. `/usr/bin/vim -c 'set tw=75'`

What are your thoughts?